### PR TITLE
Use the CI Reason for queued builds

### DIFF
--- a/src/SvnCITrigger/AzureSubversionCiController.cs
+++ b/src/SvnCITrigger/AzureSubversionCiController.cs
@@ -117,7 +117,7 @@ namespace SvnCITrigger
             {
                 Console.WriteLine(string.Format("Triggering build for {0}", buildDef.Name));
 
-                Build build = new Build() { Definition = buildDef, Project = buildDef.Project };
+                Build build = new Build() { Definition = buildDef, Project = buildDef.Project, Reason = BuildReason.IndividualCI };
                 Task<Build> taskBuild = Task.Run(() => buildClient.QueueBuildAsync(build));
                 taskBuild.Wait();
 


### PR DESCRIPTION
This makes the builds show up as "CI build for \<user\>" instead of "Manual build for \<user\>" in the DevOps UI.